### PR TITLE
Add WebSocket streaming TTS service

### DIFF
--- a/docs/stream_ws.md
+++ b/docs/stream_ws.md
@@ -1,0 +1,64 @@
+# MeloTTS 实时语音合成双流服务
+
+该文档介绍基于 WebSocket 的 MeloTTS 双流服务实现方式。服务遵循定制二进制帧协议，可实现文本流输入与音频流输出的实时交互。
+
+## 启动服务
+
+```bash
+python -m melo.stream_ws --host 0.0.0.0 --port 8010
+```
+
+服务端默认使用单模型并限制同时处理的合成任务不超过 100 个，满足百级并发需求。
+
+模型在首次请求时按需加载，所有连接断开后自动卸载并清理显存，避免长期占用资源。
+
+## 交互流程
+
+协议与消息类型与示例中保持一致：
+
+1. `START_CONNECTION` 建立连接。
+2. `START_SESSION` 指定角色音色并启动会话。
+3. 多次 `TASK_REQUEST` 发送文本片段，服务端以 `AUDIO_ONLY` `TTS_RESPONSE` 帧返回 PCM 音频。
+4. `FINISH_SESSION` 结束会话，`FINISH_CONNECTION` 关闭连接。
+
+## 多实例部署
+
+服务无状态，可水平扩展。以下示例展示了通过 Docker Compose 启动 4 个实例以承担约 100 并发连接：
+
+```yaml
+version: '3'
+services:
+  tts:
+    build: .
+    command: python -m melo.stream_ws --host 0.0.0.0 --port 8010
+    ports:
+      - "8010:8010"
+    deploy:
+      replicas: 4
+```
+
+在 Kubernetes 中部署：
+
+```yaml
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: melotts
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: melotts
+  template:
+    metadata:
+      labels:
+        app: melotts
+    spec:
+      containers:
+        - name: melotts
+          image: <your-image>
+          ports:
+            - containerPort: 8010
+```
+
+通过负载均衡将请求分发到不同实例，即可扩展到更高并发。

--- a/melo/stream_ws.py
+++ b/melo/stream_ws.py
@@ -1,0 +1,222 @@
+import asyncio
+import json
+import uuid
+from typing import Dict, Tuple
+
+from websockets.server import serve, WebSocketServerProtocol
+
+from .api import TTS
+
+# Protocol constants
+VERSION = 0b0001
+
+
+class MsgType:
+    FULL_RESPONSE = 0
+    AUDIO_ONLY = 1
+
+
+class Event:
+    START_CONNECTION = 1
+    CONNECTION_STARTED = 2
+    START_SESSION = 100
+    SESSION_STARTED = 101
+    TASK_REQUEST = 200
+    TTS_RESPONSE = 96
+    FINISH_SESSION = 102
+    SESSION_FINISHED = 152
+    FINISH_CONNECTION = 3
+    CONNECTION_FINISHED = 4
+    ERROR = 999
+
+
+MAX_CONCURRENCY = 100
+_tts_semaphore = asyncio.Semaphore(MAX_CONCURRENCY)
+_model_lock = asyncio.Lock()
+_tts_model = None
+_speaker_ids: Dict[str, int] = {}
+_active_connections = 0
+
+
+async def _get_tts_model() -> None:
+    """Lazy-load the TTS model and count active connections."""
+    global _tts_model, _speaker_ids, _active_connections
+    async with _model_lock:
+        if _tts_model is None:
+            _tts_model = TTS(language="ZH")
+            _speaker_ids = _tts_model.hps.data.spk2id
+        _active_connections += 1
+
+
+async def _release_tts_model() -> None:
+    """Decrease active connection count and free model resources if unused."""
+    global _tts_model, _speaker_ids, _active_connections
+    model = None
+    async with _model_lock:
+        _active_connections -= 1
+        if _active_connections == 0 and _tts_model is not None:
+            model = _tts_model
+            _tts_model = None
+            _speaker_ids = {}
+    if model is not None:
+        try:
+            if hasattr(model, "model"):
+                model.model.cpu()
+        except Exception:
+            pass
+        del model
+        try:
+            import torch, gc
+
+            torch.cuda.empty_cache()
+            gc.collect()
+        except Exception:
+            pass
+
+
+def pack_frame(msg_type: int, event_type: int, payload: Dict, audio_data: bytes = b"") -> bytes:
+    """Pack a frame according to the custom binary protocol."""
+    header = (VERSION << 12) | (msg_type << 8) | event_type
+    header_bytes = header.to_bytes(2, "big")
+    payload_bytes = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    payload_len = len(payload_bytes).to_bytes(4, "big")
+    if msg_type == MsgType.AUDIO_ONLY:
+        audio_len = len(audio_data).to_bytes(4, "big")
+        return header_bytes + payload_len + payload_bytes + audio_len + audio_data
+    return header_bytes + payload_len + payload_bytes
+
+
+def unpack_frame(data: bytes) -> Tuple[int, int, int, Dict]:
+    header = int.from_bytes(data[:2], "big")
+    version = (header >> 12) & 0xF
+    msg_type = (header >> 8) & 0xF
+    event_type = header & 0xFF
+    payload_len = int.from_bytes(data[2:6], "big")
+    payload_bytes = data[6:6 + payload_len]
+    payload = json.loads(payload_bytes.decode("utf-8")) if payload_len else {}
+    return version, msg_type, event_type, payload
+
+
+def pcm16(audio) -> bytes:
+    """Convert float numpy array to 16-bit PCM bytes."""
+    import numpy as np
+
+    audio = (audio * 32767).astype(np.int16)
+    return audio.tobytes()
+
+
+async def synthesize(text: str, speaker_id: int) -> bytes:
+    loop = asyncio.get_running_loop()
+    audio = await loop.run_in_executor(None, lambda: _tts_model.tts_to_file(text, speaker_id))
+    pcm = pcm16(audio)
+    del audio  # release numpy array promptly
+    return pcm
+
+
+async def handle_connection(ws: WebSocketServerProtocol):
+    await _get_tts_model()
+    session_id = str(uuid.uuid4())
+    speaker_id = None
+    try:
+        async for message in ws:
+            version, msg_type, event_type, payload = unpack_frame(message)
+            if event_type == Event.START_CONNECTION:
+                await ws.send(
+                    pack_frame(
+                        MsgType.FULL_RESPONSE,
+                        Event.CONNECTION_STARTED,
+                        {"session_id": session_id, "message": "连接已建立"},
+                    )
+                )
+            elif event_type == Event.START_SESSION:
+                role_name = payload.get("role_name")
+                if role_name not in _speaker_ids:
+                    await ws.send(
+                        pack_frame(
+                            MsgType.FULL_RESPONSE,
+                            Event.ERROR,
+                            {"code": 1002, "message": "角色不存在"},
+                        )
+                    )
+                    continue
+                speaker_id = _speaker_ids[role_name]
+                await ws.send(
+                    pack_frame(
+                        MsgType.FULL_RESPONSE,
+                        Event.SESSION_STARTED,
+                        {"session_id": session_id, "role_name": role_name},
+                    )
+                )
+            elif event_type == Event.TASK_REQUEST:
+                if speaker_id is None:
+                    await ws.send(
+                        pack_frame(
+                            MsgType.FULL_RESPONSE,
+                            Event.ERROR,
+                            {"code": 1001, "message": "会话未启动"},
+                        )
+                    )
+                    continue
+                text = payload.get("text", "")
+                async with _tts_semaphore:
+                    try:
+                        audio_bytes = await synthesize(text, speaker_id)
+                    except Exception as exc:  # pragma: no cover - log error
+                        await ws.send(
+                            pack_frame(
+                                MsgType.FULL_RESPONSE,
+                                Event.ERROR,
+                                {"code": 999, "message": str(exc)},
+                            )
+                        )
+                        continue
+                await ws.send(
+                    pack_frame(
+                        MsgType.AUDIO_ONLY,
+                        Event.TTS_RESPONSE,
+                        {"session_id": session_id},
+                        audio_bytes,
+                    )
+                )
+                del audio_bytes  # free audio buffer
+            elif event_type == Event.FINISH_SESSION:
+                await ws.send(
+                    pack_frame(
+                        MsgType.FULL_RESPONSE,
+                        Event.SESSION_FINISHED,
+                        {"session_id": session_id},
+                    )
+                )
+                speaker_id = None
+            elif event_type == Event.FINISH_CONNECTION:
+                await ws.send(
+                    pack_frame(
+                        MsgType.FULL_RESPONSE,
+                        Event.CONNECTION_FINISHED,
+                        {"session_id": session_id},
+                    )
+                )
+                break
+    finally:
+        try:
+            await ws.close()
+            await ws.wait_closed()
+        except Exception:
+            pass
+        await _release_tts_model()
+
+
+async def main(host: str = "0.0.0.0", port: int = 8010):
+    async with serve(handle_connection, host, port, max_size=None):
+        await asyncio.Future()
+
+
+if __name__ == "__main__":
+    import argparse
+
+    parser = argparse.ArgumentParser(description="MeloTTS streaming WebSocket service")
+    parser.add_argument("--host", default="0.0.0.0")
+    parser.add_argument("--port", type=int, default=8010)
+    args = parser.parse_args()
+
+    asyncio.run(main(args.host, args.port))

--- a/requirements.txt
+++ b/requirements.txt
@@ -27,3 +27,4 @@ langid==1.1.6
 tqdm
 tensorboard==2.16.2
 loguru==0.7.2
+websockets


### PR DESCRIPTION
## Summary
- add WebSocket based streaming TTS server with custom binary protocol
- document real-time dual-stream service and multi-instance deployment
- include websockets dependency
- free synthesized audio buffers and close WebSocket connections cleanly
- lazily load TTS model and unload it when last session disconnects to release GPU/CPU resources

## Testing
- `python -m py_compile melo/stream_ws.py`
- `PYTHONPATH=. pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*


------
https://chatgpt.com/codex/tasks/task_e_689af23e65d48323a81d3832267e5ff5